### PR TITLE
Enhance activity and RR management closing BIT-65

### DIFF
--- a/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/core/data/remote/dto/ActivityDto.kt
+++ b/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/core/data/remote/dto/ActivityDto.kt
@@ -31,6 +31,11 @@ data class ActivityDto(
     val rr: Int?,
     val mode: Uuid?
 ) {
+    /**
+     * Converts this DTO into an activity domain model.
+     *
+     * @return The corresponding activity model.
+     */
     fun toModel(): Activity {
         return Activity(
             id = id,

--- a/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/core/data/remote/dto/ActivityDto.kt
+++ b/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/core/data/remote/dto/ActivityDto.kt
@@ -7,7 +7,7 @@
  * File:       ActivityDto.kt
  * Module:     Valolink.shared.commonMain
  * Author:     Tim Anhalt (BitTim)
- * Modified:   24.06.26, 03:48
+ * Modified:   24.06.26, 19:10
  */
 
 package dev.bittim.valolink.core.data.remote.dto
@@ -28,7 +28,8 @@ data class ActivityDto(
     val time: Instant,
     val type: ActivityType,
     val xp: Int,
-    val rr: Int?
+    val rr: Int?,
+    val mode: Uuid?
 ) {
     fun toModel(): Activity {
         return Activity(
@@ -37,7 +38,8 @@ data class ActivityDto(
             time = time,
             type = type,
             xp = xp,
-            rr = rr
+            rr = rr,
+            mode = mode
         )
     }
 

--- a/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/core/domain/model/Activity.kt
+++ b/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/core/domain/model/Activity.kt
@@ -7,7 +7,7 @@
  * File:       Activity.kt
  * Module:     Valolink.shared.commonMain
  * Author:     Tim Anhalt (BitTim)
- * Modified:   24.06.26, 03:48
+ * Modified:   24.06.26, 19:10
  */
 
 package dev.bittim.valolink.core.domain.model
@@ -21,5 +21,6 @@ data class Activity(
     val time: Instant,
     val type: ActivityType,
     val xp: Int,
-    val rr: Int?
+    val rr: Int?,
+    val mode: Uuid?
 )

--- a/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/di/ActivityModule.kt
+++ b/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/di/ActivityModule.kt
@@ -7,7 +7,7 @@
  * File:       ActivityModule.kt
  * Module:     Valolink.shared.commonMain
  * Author:     Tim Anhalt (BitTim)
- * Modified:   24.06.26, 03:52
+ * Modified:   24.06.26, 17:49
  */
 
 package dev.bittim.valolink.feature.activity.di
@@ -23,6 +23,7 @@ val featureActivityModule = module {
     singleOf(::ParseIntUseCase)
     singleOf(::FormatScoreUseCase)
     singleOf(::MatchOutcomeFromScoreUseCase)
+    singleOf(::GetSeasonActivitiesForCurrentUserByTimeUseCase)
     singleOf(::GetCurrentSeasonActivitiesForCurrentUserUseCase)
     singleOf(::CalculateRrBeforeTimeUseCase)
     singleOf(::CalculateRrUpToIdUseCase)

--- a/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/CalculateRrBeforeTimeUseCase.kt
+++ b/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/CalculateRrBeforeTimeUseCase.kt
@@ -7,13 +7,14 @@
  * File:       CalculateRrBeforeTimeUseCase.kt
  * Module:     Valolink.shared.commonMain
  * Author:     Tim Anhalt (BitTim)
- * Modified:   24.06.26, 03:52
+ * Modified:   24.06.26, 19:21
  */
 
 package dev.bittim.valolink.feature.activity.domain.usecase
 
 import dev.bittim.valolink.core.domain.model.Activity
 import kotlin.time.Instant
+import kotlin.uuid.Uuid
 
 class CalculateRrBeforeTimeUseCase {
     /**
@@ -25,11 +26,14 @@ class CalculateRrBeforeTimeUseCase {
      */
     operator fun invoke(
         activities: List<Activity>?,
+        modeUuid: Uuid?,
         before: Instant
     ): Int? {
         if (activities == null) return null
 
-        val filteredActivities = activities.sortedBy { it.time }.takeWhile { it.time <= before }.filter { it.rr != null }
-        return filteredActivities.sumOf { it.rr!! }
+        val filteredActivities = activities.filter {
+            it.mode == modeUuid
+        }.sortedBy { it.time }.takeWhile { it.time <= before }.filter { it.rr != null }
+        return if(filteredActivities.isEmpty()) null else filteredActivities.sumOf { it.rr!! }
     }
 }

--- a/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/CalculateRrBeforeTimeUseCase.kt
+++ b/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/CalculateRrBeforeTimeUseCase.kt
@@ -18,11 +18,12 @@ import kotlin.uuid.Uuid
 
 class CalculateRrBeforeTimeUseCase {
     /**
-     * Calculates the sum of `rr` values from activities up to (and including) a specified timestamp.
+     * Calculates the sum of `rr` values for matching activities up to a given timestamp.
      *
-     * @param activities The list of activities to process.
-     * @param before The maximum timestamp to include in the sum.
-     * @return The sum of `rr` values from activities with `time` less than or equal to `before`, or `null` if `activities` is `null`.
+     * @param activities The activities to process.
+     * @param modeUuid The mode to match against each activity's mode.
+     * @param before The latest timestamp to include.
+     * @return The sum of `rr` values for activities with a matching mode and `time` less than or equal to `before`, or `null` if no matching activities contribute to the sum.
      */
     operator fun invoke(
         activities: List<Activity>?,

--- a/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/CalculateRrUpToIdUseCase.kt
+++ b/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/CalculateRrUpToIdUseCase.kt
@@ -7,7 +7,7 @@
  * File:       CalculateRrUpToIdUseCase.kt
  * Module:     Valolink.shared.commonMain
  * Author:     Tim Anhalt (BitTim)
- * Modified:   24.06.26, 03:52
+ * Modified:   24.06.26, 19:21
  */
 
 package dev.bittim.valolink.feature.activity.domain.usecase
@@ -25,13 +25,16 @@ class CalculateRrUpToIdUseCase {
      */
     operator fun invoke(
         activities: List<Activity>?,
+        modeUuid: Uuid?,
         upToInclusive: Uuid
     ): Int? {
         if (activities == null) return null
 
-        val sortedActivities = activities.sortedBy { it.time }
+        val sortedActivities = activities.filter {
+            it.mode == modeUuid
+        }.sortedBy { it.time }
         val lastIndex = sortedActivities.indexOfFirst { it.id == upToInclusive }
         val filteredActivities = sortedActivities.take(lastIndex + 1).filter { it.rr != null }
-        return filteredActivities.sumOf { it.rr!! }
+        return if (filteredActivities.isEmpty()) null else filteredActivities.sumOf { it.rr!! }
     }
 }

--- a/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/CalculateRrUpToIdUseCase.kt
+++ b/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/CalculateRrUpToIdUseCase.kt
@@ -17,11 +17,12 @@ import kotlin.uuid.Uuid
 
 class CalculateRrUpToIdUseCase {
     /**
-     * Calculates the sum of `rr` values from activities up to (and including) a specified identifier.
+     * Calculates the sum of `rr` values for matching activities up to a specified identifier.
      *
-     * @param activities The list of activities to process.
-     * @param upToInclusive The maximum activity identifier to include in the sum.
-     * @return The sum of `rr` values from activities sorted by time up to `id` equal to `upToInclusive`, or `null` if `activities` is `null`.
+     * @param activities The activities to process.
+     * @param modeUuid The activity mode to match.
+     * @param upToInclusive The activity identifier to include up to.
+     * @return The sum of `rr` values for matching activities up to `upToInclusive`, or `null` if no matching `rr` values are found or `activities` is `null`.
      */
     operator fun invoke(
         activities: List<Activity>?,

--- a/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/GetSeasonActivitiesForCurrentUserByTimeUseCase.kt
+++ b/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/GetSeasonActivitiesForCurrentUserByTimeUseCase.kt
@@ -24,6 +24,13 @@ class GetSeasonActivitiesForCurrentUserByTimeUseCase(
     private val valoSeasonRepo: ValoSeasonRepo,
     private val activityRepo: ActivityRepo
 ) {
+    /**
+     * Gets the current user's activities for the season active at the specified time.
+     *
+     * @param time The point in time used to determine the active season.
+     * @param locale The locale used when resolving the season.
+     * @return The activities for the current user in the active season, or an empty list if no current user or season is available.
+     */
     suspend operator fun invoke(time: Instant, locale: String? = null): List<Activity> {
         val userId = authRepo.getCurrentUserId() ?: return emptyList()
         val season = valoSeasonRepo.observe(time, locale).firstOrNull() ?: return emptyList()

--- a/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/GetSeasonActivitiesForCurrentUserByTimeUseCase.kt
+++ b/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/GetSeasonActivitiesForCurrentUserByTimeUseCase.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Tim Anhalt (BitTim)
+ *
+ * Project:    Valolink
+ * License:    GPLv3
+ *
+ * File:       GetSeasonActivitiesForCurrentUserByTimeUseCase.kt
+ * Module:     Valolink.shared.commonMain
+ * Author:     Tim Anhalt (BitTim)
+ * Modified:   24.06.26, 17:48
+ */
+
+package dev.bittim.valolink.feature.activity.domain.usecase
+
+import dev.bittim.valolink.core.domain.model.Activity
+import dev.bittim.valolink.core.domain.repo.ActivityRepo
+import dev.bittim.valolink.core.domain.repo.AuthRepo
+import dev.bittim.valolink.core.domain.repo.ValoSeasonRepo
+import kotlinx.coroutines.flow.firstOrNull
+import kotlin.time.Instant
+
+class GetSeasonActivitiesForCurrentUserByTimeUseCase(
+    private val authRepo: AuthRepo,
+    private val valoSeasonRepo: ValoSeasonRepo,
+    private val activityRepo: ActivityRepo
+) {
+    suspend operator fun invoke(time: Instant, locale: String? = null): List<Activity> {
+        val userId = authRepo.getCurrentUserId() ?: return emptyList()
+        val season = valoSeasonRepo.observe(time, locale).firstOrNull() ?: return emptyList()
+
+        return activityRepo.get(userId, season)
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/MapRrToRank.kt
+++ b/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/MapRrToRank.kt
@@ -26,11 +26,12 @@ class MapRrToRank(
     private val valoRankRepo: ValoRankRepo
 ) {
     /**
-     * Converts an RR rating value into its corresponding rank at a specified time.
+     * Maps an RR value to the matching rank for the active season at the given time.
      *
-     * @param time The instant at which to resolve the rank.
+     * @param rr The RR value to resolve, or `null` to return the tier-0 rank.
+     * @param time The instant used to determine the active season.
      * @param locale Optional locale for rank data retrieval.
-     * @return A `Rank` with the matched rank entry and remaining RR points, or `null` if the rank cannot be determined.
+     * @return The resolved `Rank`, or `null` if the season, rank table, or matching rank cannot be found.
      */
     suspend operator fun invoke(rr: Int?, time: Instant, locale: String? = null): Rank? {
         val season = valoSeasonRepo.observe(time, locale).firstOrNull() ?: return null

--- a/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/MapRrToRank.kt
+++ b/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/domain/usecase/MapRrToRank.kt
@@ -7,7 +7,7 @@
  * File:       MapRrToRank.kt
  * Module:     Valolink.shared.commonMain
  * Author:     Tim Anhalt (BitTim)
- * Modified:   23.06.26, 03:30
+ * Modified:   24.06.26, 19:30
  */
 
 package dev.bittim.valolink.feature.activity.domain.usecase
@@ -32,18 +32,26 @@ class MapRrToRank(
      * @param locale Optional locale for rank data retrieval.
      * @return A `Rank` with the matched rank entry and remaining RR points, or `null` if the rank cannot be determined.
      */
-    suspend operator fun invoke(rr: Int, time: Instant, locale: String? = null): Rank? {
+    suspend operator fun invoke(rr: Int?, time: Instant, locale: String? = null): Rank? {
         val season = valoSeasonRepo.observe(time, locale).firstOrNull() ?: return null
         val competitiveSeason = valoCompetitiveSeasonRepo.observeBySeason(season.uuid).firstOrNull() ?: return null
-        val ranks = valoRankRepo.observeAll(competitiveSeason.rankTable, locale).firstOrNull()?.filter {
+
+        val ranks = valoRankRepo.observeAll(competitiveSeason.rankTable, locale).firstOrNull()
+        val filteredRanks = ranks?.filter {
             !it.division.contains("UNRANKED") && !it.division.contains("INVALID")
         } ?: return null
 
-        val tierOffset = ranks.minOfOrNull { it.tier } ?: return null
+        if (rr == null) return ranks.firstOrNull { it.tier == 0 }?.let {
+            Rank(rank = it, rr = 0)
+        }
+
+        val tierOffset = filteredRanks.minOfOrNull { it.tier } ?: return null
         val relativeTier = floor(rr.toDouble() / RR_PER_RANK).toInt()
         val calculatedTier = relativeTier + tierOffset
         val calculatedRr = rr - relativeTier * RR_PER_RANK
-        val rank = ranks.firstOrNull { it.tier == calculatedTier } ?: return null
+
+        val actualTier = calculatedTier.coerceAtMost(filteredRanks.lastOrNull()?.tier ?: 0)
+        val rank = filteredRanks.firstOrNull { it.tier == actualTier } ?: return null
 
         return Rank(
             rank = rank,

--- a/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/ui/screen/addFlow/ActivityAddFlowViewModel.kt
+++ b/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/ui/screen/addFlow/ActivityAddFlowViewModel.kt
@@ -63,6 +63,11 @@ class ActivityAddFlowViewModel(
     private var modes: List<ValoMode>? = null
     private var activities: List<Activity>? = null
 
+    /**
+     * Moves the add flow back by one step or exits the screen from the first step.
+     *
+     * @param navBack Called when the current step is the first step and the screen should navigate back.
+     */
     private fun handleBack(
         navBack: () -> Unit
     ) {
@@ -86,6 +91,12 @@ class ActivityAddFlowViewModel(
         }
     }
 
+    /**
+     * Recomputes the derived UI state from the current selections and loaded data.
+     *
+     * Updates the visible cards, button enablement, match summary, and ranked indicators using the
+     * selected mode, map, score, time, and season activities.
+     */
     private fun updateUiState() {
         uiStateUpdateJob?.cancel()
         uiStateUpdateJob = viewModelScope.launch {
@@ -163,6 +174,9 @@ class ActivityAddFlowViewModel(
         }
     }
 
+    /**
+     * Loads the season activities for the selected time.
+     */
     private fun updateActivities() {
         activityFetchJob?.cancel()
         activityFetchJob = viewModelScope.launch {
@@ -170,6 +184,11 @@ class ActivityAddFlowViewModel(
         }
     }
 
+    /**
+     * Updates the selected mode and resets dependent selections when the mode category changes.
+     *
+     * @param uuid The selected mode identifier.
+     */
     private fun selectMode(uuid: Uuid?) {
         val oldCategory = modes?.firstOrNull { it.uuid == _state.value.modeUuid }?.category
         val newCategory = modes?.firstOrNull { it.uuid == uuid }?.category
@@ -274,6 +293,13 @@ class ActivityAddFlowViewModel(
         updateUiState()
     }
 
+    /**
+     * Updates the selected time from the provided date and clock values.
+     *
+     * @param dateMillis The selected date in epoch milliseconds.
+     * @param hour The selected hour of day.
+     * @param minute The selected minute.
+     */
     private fun updateTime(dateMillis: Long, hour: Int, minute: Int) {
         val localDate = Instant.fromEpochMilliseconds(dateMillis).toLocalDateTime(timeZone).date
         val localTime = LocalTime(hour, minute)

--- a/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/ui/screen/addFlow/ActivityAddFlowViewModel.kt
+++ b/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/ui/screen/addFlow/ActivityAddFlowViewModel.kt
@@ -123,7 +123,8 @@ class ActivityAddFlowViewModel(
             val isRankedSelected = _state.value.isRankedSelected
             val (prevRank, rank) = if (isRankedSelected) {
                 val totalRr = calculateRrBeforeTimeUseCase(activities, currentMode?.uuid, time)
-                Pair(mapRrToRank(totalRr, time), mapRrToRank(totalRr?.plus(rr ?: 0), time))
+                val currentTotalRr = rr?.let { (totalRr ?: 0) + it } ?: totalRr
+                Pair(mapRrToRank(totalRr, time), mapRrToRank(currentTotalRr, time))
             } else Pair(null, null)
             val rankChanged = prevRank?.rank?.tier != rank?.rank?.tier
 

--- a/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/ui/screen/addFlow/ActivityAddFlowViewModel.kt
+++ b/mobile/shared/src/commonMain/kotlin/dev/bittim/valolink/feature/activity/ui/screen/addFlow/ActivityAddFlowViewModel.kt
@@ -7,7 +7,7 @@
  * File:       ActivityAddFlowViewModel.kt
  * Module:     Valolink.shared.commonMain
  * Author:     Tim Anhalt (BitTim)
- * Modified:   17.06.26, 14:21
+ * Modified:   24.06.26, 19:45
  */
 
 package dev.bittim.valolink.feature.activity.ui.screen.addFlow
@@ -20,9 +20,7 @@ import dev.bittim.valolink.core.domain.extension.toLocalizedString
 import dev.bittim.valolink.core.domain.model.*
 import dev.bittim.valolink.core.domain.repo.ValoMapRepo
 import dev.bittim.valolink.core.domain.repo.ValoModeRepo
-import dev.bittim.valolink.feature.activity.domain.usecase.FormatScoreUseCase
-import dev.bittim.valolink.feature.activity.domain.usecase.MatchOutcomeFromScoreUseCase
-import dev.bittim.valolink.feature.activity.domain.usecase.ParseIntUseCase
+import dev.bittim.valolink.feature.activity.domain.usecase.*
 import dev.bittim.valolink.feature.activity.ui.components.map.MapCardState
 import dev.bittim.valolink.feature.activity.ui.components.match.RrChipState
 import dev.bittim.valolink.feature.activity.ui.components.mode.ModeCardState
@@ -40,24 +38,30 @@ class ActivityAddFlowViewModel(
     private val parseIntUseCase: ParseIntUseCase,
     private val formatScoreUseCase: FormatScoreUseCase,
     private val matchOutcomeFromScoreUseCase: MatchOutcomeFromScoreUseCase,
+    private val getSeasonActivitiesForCurrentUserByTimeUseCase: GetSeasonActivitiesForCurrentUserByTimeUseCase,
+    private val calculateRrBeforeTimeUseCase: CalculateRrBeforeTimeUseCase,
+    private val mapRrToRank: MapRrToRank,
 
     private val valoModeRepo: ValoModeRepo,
-    private val valoMapRepo: ValoMapRepo
+    private val valoMapRepo: ValoMapRepo,
 ) : ViewModel() {
     private val _state = MutableStateFlow(ActivityAddFlowState())
     val state = _state.asStateFlow()
 
     val timeZone = TimeZone.currentSystemDefault()
 
+    private var uiStateUpdateJob: Job? = null
     private var placeholderFetchJob: Job? = null
     private var modeObserveJob: Job? = null
     private var mapObserveJob: Job? = null
+    private var activityFetchJob: Job? = null
 
     private var modePlaceholder: String = ""
     private var mapPlaceholder: String = ""
 
     private var maps: List<SimpleValoMap>? = null
     private var modes: List<ValoMode>? = null
+    private var activities: List<Activity>? = null
 
     private fun handleBack(
         navBack: () -> Unit
@@ -83,63 +87,87 @@ class ActivityAddFlowViewModel(
     }
 
     private fun updateUiState() {
-        val currentMode = modes?.firstOrNull { it.uuid == _state.value.modeUuid }
-        val currentMap = maps?.firstOrNull { it.uuid == _state.value.mapUuid }
+        uiStateUpdateJob?.cancel()
+        uiStateUpdateJob = viewModelScope.launch {
+            activityFetchJob?.join()
 
-        val scoreA = _state.value.scoreA
-        val scoreB = _state.value.scoreB
-        val surrender = _state.value.surrender
-        val modeCategory = currentMode?.category ?: ValoModeCategory.Standard
+            val currentMode = modes?.firstOrNull { it.uuid == _state.value.modeUuid }
+            val currentMap = maps?.firstOrNull { it.uuid == _state.value.mapUuid }
 
-        val isPlacementScoreType = currentMode?.category?.getScoreType() == ValoModeCategory.ScoreType.Placement
-        val score = formatScoreUseCase(scoreA, scoreB, modeCategory)
-        val matchOutcome = matchOutcomeFromScoreUseCase(scoreA, scoreB, surrender, modeCategory) ?: MatchOutcome.Draw
+            val scoreA = _state.value.scoreA
+            val scoreB = _state.value.scoreB
+            val surrender = _state.value.surrender
+            val modeCategory = currentMode?.category ?: ValoModeCategory.Standard
 
-        val time = _state.value.time.toLocalizedString()
-        val xp = _state.value.xp
-        val rr = _state.value.rr
+            val isPlacementScoreType = currentMode?.category?.getScoreType() == ValoModeCategory.ScoreType.Placement
+            val score = formatScoreUseCase(scoreA, scoreB, modeCategory)
+            val matchOutcome =
+                matchOutcomeFromScoreUseCase(scoreA, scoreB, surrender, modeCategory) ?: MatchOutcome.Draw
 
-        val enableModeContinueButton = modes != null && _state.value.modeUuid != null
-        val enableMapContinueButton = maps != null && _state.value.mapUuid != null
-        val enableScoreContinueButton = scoreA != null && _state.value.scoreAError == null && (isPlacementScoreType || scoreB != null && _state.value.scoreBError == null)
-        val enableResultContinueButton = false
+            val time = _state.value.time
+            val localizedTimeString = _state.value.time.toLocalizedString()
+            val xp = _state.value.xp
+            val rr = _state.value.rr
 
-        _state.update { it.copy(
-            modeCardStates = modes?.map { mode -> ModeCardState.from(mode) },
-            mapCardStates = maps?.filter { map ->
-                map.category == currentMode?.category?.let { modeCategory ->  ValoMapCategory.from(modeCategory) }
-            }?.map { map -> MapCardState.from(map) },
-            isPlacementScoreType = isPlacementScoreType,
-            supportsRanked = currentMode?.canBeRanked ?: false,
+            val isRankedSelected = _state.value.isRankedSelected
+            val (prevRank, rank) = if (isRankedSelected) {
+                val totalRr = calculateRrBeforeTimeUseCase(activities, currentMode?.uuid, time)
+                Pair(mapRrToRank(totalRr, time), mapRrToRank(totalRr?.plus(rr ?: 0), time))
+            } else Pair(null, null)
+            val rankChanged = prevRank?.rank?.tier != rank?.rank?.tier
 
-            enableModeContinueButton = enableModeContinueButton,
-            enableMapContinueButton = enableMapContinueButton,
-            enableScoreContinueButton = enableScoreContinueButton,
-            enableResultContinueButton = enableResultContinueButton,
+            val enableModeContinueButton = modes != null && _state.value.modeUuid != null
+            val enableMapContinueButton = maps != null && _state.value.mapUuid != null
+            val enableScoreContinueButton =
+                scoreA != null && _state.value.scoreAError == null && (isPlacementScoreType || scoreB != null && _state.value.scoreBError == null)
+            val enableResultContinueButton = false
 
-            matchCardState = it.matchCardState.copy(
-                modeName = currentMode?.displayName ?: modePlaceholder,
-                mapName = currentMap?.displayName ?: mapPlaceholder,
-                iconState = it.matchCardState.iconState.copy(
-                    iconUrl = currentMode?.displayIcon,
-                    mapImageUrl = currentMap?.splash,
-                    outcome = matchOutcome,
-                    rrChipState = rr?.let { rr ->
-                        RrChipState(
-                            rr = rr,
-                            rankChanged = false
-                        )
-                    },
-                ),
-                scoreChipState = it.matchCardState.scoreChipState.copy(
-                    score = score,
-                    outcome = matchOutcome,
-                    wasSurrender = surrender in listOf(MatchEndReason.SURRENDER_A, MatchEndReason.SURRENDER_B)
-                ),
-                time = time,
-                xp = xp,
-            ),
-        ) }
+            val iconUrl = if (rank != null) rank.rank.largeIcon else currentMode?.displayIcon
+
+            _state.update {
+                it.copy(
+                    modeCardStates = modes?.map { mode -> ModeCardState.from(mode) },
+                    mapCardStates = maps?.filter { map ->
+                        map.category == currentMode?.category?.let { modeCategory -> ValoMapCategory.from(modeCategory) }
+                    }?.map { map -> MapCardState.from(map) },
+                    isPlacementScoreType = isPlacementScoreType,
+                    supportsRanked = currentMode?.canBeRanked ?: false,
+
+                    enableModeContinueButton = enableModeContinueButton,
+                    enableMapContinueButton = enableMapContinueButton,
+                    enableScoreContinueButton = enableScoreContinueButton,
+                    enableResultContinueButton = enableResultContinueButton,
+
+                    matchCardState = it.matchCardState.copy(
+                        modeName = currentMode?.displayName ?: modePlaceholder,
+                        mapName = currentMap?.displayName ?: mapPlaceholder,
+                        iconState = it.matchCardState.iconState.copy(
+                            iconUrl = iconUrl,
+                            mapImageUrl = currentMap?.splash,
+                            outcome = matchOutcome,
+                            rrChipState = RrChipState(
+                                rr = rank?.rr ?: 0,
+                                rankChanged = rankChanged
+                            ),
+                        ),
+                        scoreChipState = it.matchCardState.scoreChipState.copy(
+                            score = score,
+                            outcome = matchOutcome,
+                            wasSurrender = surrender in listOf(MatchEndReason.SURRENDER_A, MatchEndReason.SURRENDER_B)
+                        ),
+                        time = localizedTimeString,
+                        xp = xp,
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun updateActivities() {
+        activityFetchJob?.cancel()
+        activityFetchJob = viewModelScope.launch {
+            activities = getSeasonActivitiesForCurrentUserByTimeUseCase(_state.value.time)
+        }
     }
 
     private fun selectMode(uuid: Uuid?) {
@@ -252,6 +280,7 @@ class ActivityAddFlowViewModel(
         val newTime = LocalDateTime(localDate, localTime).toInstant(timeZone)
 
         _state.update { it.copy(time = newTime) }
+        updateActivities()
         updateUiState()
     }
 
@@ -320,6 +349,8 @@ class ActivityAddFlowViewModel(
             modePlaceholder = getString(Res.string.activity_add_flow_mode_placeholder)
             mapPlaceholder = getString(Res.string.activity_add_flow_map_placeholder)
         }
+
+        updateActivities()
 
         modeObserveJob?.cancel()
         modeObserveJob = viewModelScope.launch {

--- a/supabase/migrations/20260331231508_user_init.sql
+++ b/supabase/migrations/20260331231508_user_init.sql
@@ -83,6 +83,7 @@ create table public.activities (
     type text not null check (type in ('MATCH', 'RR_REFUND', 'XP_CORRECTION')),
     xp integer not null default 0,
     rr integer default null,
+    mode uuid default null check ((not (type = 'MATCH' or type = 'RR_REFUND')) or mode is not null),
 
     constraint activities_pkey primary key (user_id, id),
     constraint activities_user_id_fkey foreign key (user_id) references users(id) on update cascade on delete cascade


### PR DESCRIPTION
- Added `GetSeasonActivitiesForCurrentUserByTimeUseCase` for fetching user activities within a season by time.
- Updated `MapRrToRank` to handle `null` RR values and improve tier calculation.
- Modified `CalculateRrBeforeTimeUseCase` and `CalculateRrUpToIdUseCase` to support mode-based filtering.
- Extended `Activity` model and `ActivityDto` to include `mode` property.
- Adjusted DI in `ActivityModule` to provide the new use case.
- Refined `ActivityAddFlowViewModel` to utilize the new use case and calculate RR accurately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added season-based activity loading for the current user by selected time.
  * Extended the activity add flow to use mode-aware ranked RR/rank details.

* **Bug Fixes**
  * RR calculations now filter by the selected mode and return null when no matching data exists.
  * Rank mapping now supports nullable RR, ignores invalid/unranked divisions, and clamps tiers to available values.
  * Activity data now carries mode information across screens.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->